### PR TITLE
Split release out of CI; tighten CI permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
     branches: [ main ]
 
 permissions:
-  contents: write
+  contents: read
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -37,42 +37,3 @@ jobs:
 
       - name: Display coverage
         run: go tool cover -func=coverage.out
-
-  release:
-    name: Release
-    runs-on: ubuntu-latest
-    needs: test
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
-
-      - name: Set up Go
-        uses: actions/setup-go@v6
-        with:
-          go-version: '1.26'
-
-      - name: Generate version
-        id: version
-        run: |
-          LATEST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "v0.0.0")
-          IFS='.' read -r major minor patch <<< "${LATEST_TAG/v/}"
-          NEW_VERSION="v$major.$minor.$((patch+1))"
-          echo "new_version=$NEW_VERSION" >> $GITHUB_OUTPUT
-          echo "Creating new version: $NEW_VERSION"
-
-      - name: Create tag
-        run: |
-          git config --global user.name "GitHub Actions"
-          git config --global user.email "actions@github.com"
-          git tag -a ${{ steps.version.outputs.new_version }} -m "Release ${{ steps.version.outputs.new_version }}"
-          git push origin ${{ steps.version.outputs.new_version }}
-
-      - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
-        with:
-          tag_name: ${{ steps.version.outputs.new_version }}
-          name: Release ${{ steps.version.outputs.new_version }}
-          generate_release_notes: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,53 @@
+name: Release
+
+on:
+  push:
+    branches: [ main ]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: release
+  cancel-in-progress: false
+
+jobs:
+  release:
+    name: Release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version: '1.26'
+
+      - name: Generate version
+        id: version
+        run: |
+          LATEST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "v0.0.0")
+          IFS='.' read -r major minor patch <<< "${LATEST_TAG/v/}"
+          NEW_VERSION="v$major.$minor.$((patch+1))"
+          echo "new_version=$NEW_VERSION" >> $GITHUB_OUTPUT
+          echo "Creating new version: $NEW_VERSION"
+
+      - name: Create tag
+        run: |
+          git config --global user.name "GitHub Actions"
+          git config --global user.email "actions@github.com"
+          git tag -a ${{ steps.version.outputs.new_version }} -m "Release ${{ steps.version.outputs.new_version }}"
+          git push origin ${{ steps.version.outputs.new_version }}
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ steps.version.outputs.new_version }}
+          name: Release ${{ steps.version.outputs.new_version }}
+          generate_release_notes: true


### PR DESCRIPTION
## Summary

- Move the release job from `ci.yml` into a new `release.yml` triggered **only** on `push:main` and `workflow_dispatch`.
- `ci.yml` now declares `permissions: contents: read` at the workflow level (was previously `contents: write`).
- Release job retains `contents: write` at job scope only.

## Why

Defense-in-depth on top of the fork-PR approval setting. `release.yml` has no `pull_request` trigger and a fork PR cannot fire `push:main` or `workflow_dispatch`, so it's structurally unreachable from any PR-driven trigger.

## Test plan

- [ ] Merge → confirm release job fires on push to main
- [ ] Open a noop PR → confirm only test job runs